### PR TITLE
Rename gadgets to announcements for demo

### DIFF
--- a/api/announcements/routes.go
+++ b/api/announcements/routes.go
@@ -1,4 +1,4 @@
-package gadgets
+package announcements
 
 import (
 	"encoding/json"
@@ -21,11 +21,11 @@ func Routes(database db.Provider) *chi.Mux {
 	return router
 }
 
-// Gets all gadgets from the database
+// Gets all announcements from the database
 func GetAll(database db.Provider) http.HandlerFunc {
 	// Use a closure to inject the database provider
 	return func(w http.ResponseWriter, r *http.Request) {
-		gadgets, err := database.GetAllGadgets(r.Context())
+		announcements, err := database.GetAllAnnouncements(r.Context())
 		if err != nil {
 			util.Error(w, err)
 			return
@@ -33,7 +33,7 @@ func GetAll(database db.Provider) http.HandlerFunc {
 
 		// Return the list in a JSON object
 		jsonResponse, err := json.Marshal(map[string]interface{}{
-			"announcements": gadgets,
+			"announcements": announcements,
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -46,7 +46,7 @@ func GetAll(database db.Provider) http.HandlerFunc {
 	}
 }
 
-// Gets a single gadget from the database by its ID
+// Gets a single announcement from the database by its ID
 func GetSingle(database db.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
@@ -56,14 +56,14 @@ func GetSingle(database db.Provider) http.HandlerFunc {
 			return
 		}
 
-		gadget, err := database.GetGadget(r.Context(), id)
+		announcement, err := database.GetAnnouncement(r.Context(), id)
 		if err != nil {
 			util.Error(w, err)
 			return
 		}
 
-		// Return the single gadget as the top-level JSON
-		jsonResponse, err := json.Marshal(gadget)
+		// Return the single announcement as the top-level JSON
+		jsonResponse, err := json.Marshal(announcement)
 		if err != nil {
 			util.ErrorWithCode(w, err, http.StatusInternalServerError)
 			return
@@ -75,24 +75,24 @@ func GetSingle(database db.Provider) http.HandlerFunc {
 	}
 }
 
-// Creates a new gadget in the database
+// Creates a new announcement in the database
 func Create(database db.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var gadget types.Gadget
-		err := json.NewDecoder(r.Body).Decode(&gadget)
+		var announcement types.Announcement
+		err := json.NewDecoder(r.Body).Decode(&announcement)
 		if err != nil {
 			util.Error(w, err)
 			return
 		}
 
-		err = database.CreateGadget(r.Context(), gadget)
+		err = database.CreateAnnouncement(r.Context(), announcement)
 		if err != nil {
 			util.Error(w, err)
 			return
 		}
 
-		// Return the single gadget as the top-level JSON
-		jsonResponse, err := json.Marshal(gadget)
+		// Return the single announcement as the top-level JSON
+		jsonResponse, err := json.Marshal(announcement)
 		if err != nil {
 			util.ErrorWithCode(w, err, http.StatusInternalServerError)
 			return
@@ -104,7 +104,7 @@ func Create(database db.Provider) http.HandlerFunc {
 	}
 }
 
-// Deletes a gadget in the database
+// Deletes a announcement in the database
 func Delete(database db.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
@@ -114,7 +114,7 @@ func Delete(database db.Provider) http.HandlerFunc {
 			return
 		}
 
-		err := database.DeleteGadget(r.Context(), id)
+		err := database.DeleteAnnouncement(r.Context(), id)
 		if err != nil {
 			util.Error(w, err)
 			return
@@ -124,7 +124,7 @@ func Delete(database db.Provider) http.HandlerFunc {
 	}
 }
 
-// Updates a gadget in the database
+// Updates a announcement in the database
 func Update(database db.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
@@ -141,13 +141,13 @@ func Update(database db.Provider) http.HandlerFunc {
 			return
 		}
 
-		updated, err := database.UpdateGadget(r.Context(), id, partial)
+		updated, err := database.UpdateAnnouncement(r.Context(), id, partial)
 		if err != nil {
 			util.Error(w, err)
 			return
 		}
 
-		// Return the updated gadget as the top-level JSON
+		// Return the updated announcement as the top-level JSON
 		jsonResponse, err := json.Marshal(updated)
 		if err != nil {
 			util.ErrorWithCode(w, err, http.StatusInternalServerError)

--- a/api/db/db.go
+++ b/api/db/db.go
@@ -11,14 +11,14 @@ type Provider interface {
 	Connect(ctx context.Context) error
 	Disconnect(ctx context.Context) error
 
-	GadgetProvider
+	AnnouncementProvider
 }
 
-// Provides CRUD operations for type.Gadget structs
-type GadgetProvider interface {
-	GetGadget(ctx context.Context, id string) (*types.Gadget, error)
-	GetAllGadgets(ctx context.Context) ([]types.Gadget, error)
-	CreateGadget(ctx context.Context, gadget types.Gadget) error
-	DeleteGadget(ctx context.Context, id string) error
-	UpdateGadget(ctx context.Context, id string, update map[string]interface{}) (*types.Gadget, error)
+// Provides CRUD operations for type.Announcement structs
+type AnnouncementProvider interface {
+	GetAnnouncement(ctx context.Context, id string) (*types.Announcement, error)
+	GetAllAnnouncements(ctx context.Context) ([]types.Announcement, error)
+	CreateAnnouncement(ctx context.Context, announcement types.Announcement) error
+	DeleteAnnouncement(ctx context.Context, id string) error
+	UpdateAnnouncement(ctx context.Context, id string, update map[string]interface{}) (*types.Announcement, error)
 }

--- a/api/gadgets/routes.go
+++ b/api/gadgets/routes.go
@@ -33,16 +33,16 @@ func GetAll(database db.Provider) http.HandlerFunc {
 
 		// Return the list in a JSON object
 		jsonResponse, err := json.Marshal(map[string]interface{}{
-			"gadgets": gadgets,
+			"announcements": gadgets,
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(jsonResponse)
-		w.Header().Set("Content-Type", "application/json")
 	}
 }
 
@@ -69,9 +69,9 @@ func GetSingle(database db.Provider) http.HandlerFunc {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(jsonResponse)
-		w.Header().Set("Content-Type", "application/json")
 	}
 }
 
@@ -98,9 +98,9 @@ func Create(database db.Provider) http.HandlerFunc {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		w.Write(jsonResponse)
-		w.Header().Set("Content-Type", "application/json")
 	}
 }
 
@@ -120,7 +120,7 @@ func Delete(database db.Provider) http.HandlerFunc {
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 
@@ -154,8 +154,8 @@ func Update(database db.Provider) http.HandlerFunc {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(jsonResponse)
-		w.Header().Set("Content-Type", "application/json")
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/render"
 	"github.com/jd-116/klemis-kitchen-api/db"
-	"github.com/jd-116/klemis-kitchen-api/gadgets"
+	"github.com/jd-116/klemis-kitchen-api/announcements"
 )
 
 func Routes(database db.Provider) *chi.Mux {
@@ -37,7 +37,7 @@ func Routes(database db.Provider) *chi.Mux {
 		})
 
 		// Proof of concept routes
-		r.Mount("/announcements", gadgets.Routes(database))
+		r.Mount("/announcements", announcements.Routes(database))
 	})
 
 	return router

--- a/api/server.go
+++ b/api/server.go
@@ -37,7 +37,7 @@ func Routes(database db.Provider) *chi.Mux {
 		})
 
 		// Proof of concept routes
-		r.Mount("/gadgets", gadgets.Routes(database))
+		r.Mount("/announcements", gadgets.Routes(database))
 	})
 
 	return router

--- a/api/types/announcement.go
+++ b/api/types/announcement.go
@@ -1,6 +1,6 @@
 package types
 
-type Gadget struct {
+type Announcement struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Timestamp string `json:"timestamp"`

--- a/api/types/gadget.go
+++ b/api/types/gadget.go
@@ -1,10 +1,10 @@
 package types
 
 type Gadget struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Stock       int    `json:"stock"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Timestamp string `json:"timestamp"`
+	Important bool   `json:"important"`
 }
 
 type ErrorResponse struct {


### PR DESCRIPTION
For context, gadgets is the name of the test API objects used as a part of implementing the proof of concept API. However, when presenting, we changed gadgets to announcements to make it clearer for our audience and make it easier to understand the motivation behind why the API exists.
